### PR TITLE
Include anonymous categories when evaluating cursor entities.

### DIFF
--- a/OCDiff/OCDAPIComparator.m
+++ b/OCDiff/OCDAPIComparator.m
@@ -53,12 +53,12 @@
     NSMutableDictionary *firstPass = [NSMutableDictionary dictionary];
     for (NSString *USR in api) {
         NSString *fuzzyUSR = [self fuzzyUSRForUSR:USR];
-        NSMutableArray *fuzzyUSRs = firstPass[fuzzyUSR];
-        if (!fuzzyUSRs) {
-            fuzzyUSRs = [NSMutableArray array];
-            firstPass[fuzzyUSR] = fuzzyUSRs;
+        NSMutableArray *USRs = firstPass[fuzzyUSR];
+        if (!USRs) {
+            USRs = [NSMutableArray array];
+            firstPass[fuzzyUSR] = USRs;
         }
-        [fuzzyUSRs addObject:USR];
+        [USRs addObject:USR];
     }
 
     // Second pass flattens the fuzzy USRs by sorting their line numbers

--- a/OCDiff/OCDAPIComparator.m
+++ b/OCDiff/OCDAPIComparator.m
@@ -51,18 +51,15 @@
 - (NSDictionary *)fuzzyAPIWithAPI:(NSDictionary *)api {
     NSMutableDictionary *fuzzyAPI = [NSMutableDictionary dictionary];
     for (NSString *USR in api) {
-        NSString *fuzzyUSR = [self fuzzyUSRForUSR:USR];
+        NSString *baseFuzzyUSR = [self fuzzyUSRForUSR:USR];
+        NSString *fuzzyUSR = baseFuzzyUSR;
+        NSInteger ix = 0;
+        while (fuzzyAPI[fuzzyUSR]) {
+            ix++;
+            fuzzyUSR = [baseFuzzyUSR stringByAppendingString:[@(ix) stringValue]];
+        }
         NSAssert(!fuzzyAPI[fuzzyUSR], @"Existing USR found %@ %@.", fuzzyUSR, USR);
         fuzzyAPI[fuzzyUSR] = api[USR];
-
-#if 0
-        NSMutableArray *fuzzyUSRs = fuzzyAPI[fuzzyUSR];
-        if (!fuzzyUSRs) {
-            fuzzyUSRs = [NSMutableArray array];
-            fuzzyAPI[fuzzyUSR] = fuzzyUSRs;
-        }
-        [fuzzyUSRs addObject:api[USR]];
-#endif
     }
     return fuzzyAPI;
 }

--- a/OCDiff/OCDAPIComparator.m
+++ b/OCDiff/OCDAPIComparator.m
@@ -200,7 +200,11 @@
 - (BOOL)shouldIncludeEntityAtCursor:(PLClangCursor *)cursor {
     if ((cursor.isDeclaration && [self shouldIncludeDeclarationAtCursor:cursor]) ||
         (cursor.kind == PLClangCursorKindMacroDefinition && [self shouldIncludeMacroDefinitionAtCursor:cursor])) {
-        return ([cursor.spelling length] > 0 && [cursor.spelling hasPrefix:@"_"] == NO);
+        BOOL isPrivateAPI = [cursor.spelling hasPrefix:@"_"] == YES;
+        if (cursor.kind == PLClangCursorKindObjCCategoryDeclaration && !isPrivateAPI) {
+            return YES;
+        }
+        return ([cursor.spelling length] > 0 && !isPrivateAPI);
     }
 
     return NO;

--- a/OCDiffTests/OCDAPIComparatorTests.m
+++ b/OCDiffTests/OCDAPIComparatorTests.m
@@ -476,6 +476,24 @@ static NSString * const OCDTestPath = @"test.h";
                       addition:@"@interface Base @end @interface Base () @property int testProperty; @end"];
 }
 
+- (void)testTwoAnonymousCategory {
+    [self testAddRemoveForName:@"Base ()"
+                          base:@"@interface Base @end @interface Base () @end"
+                      addition:@"@interface Base @end @interface Base () @end @interface Base () @end"];
+}
+
+- (void)testTwoAnonymousCategoryMethod {
+    [self testAddRemoveForName:@"-[Base testMethod]"
+                          base:@"@interface Base @end @interface Base () @end @interface Base () @end"
+                      addition:@"@interface Base @end @interface Base () -(void)testMethod; @end @interface Base () @end"];
+}
+
+- (void)testTwoAnonymousCategoryProperty {
+    [self testAddRemoveForName:@"Base.testProperty"
+                          base:@"@interface Base @end @interface Base () @end @interface Base () @end"
+                      addition:@"@interface Base @end @interface Base () @property int testProperty; @end @interface Base () @end"];
+}
+
 - (void)testCategoryModificationAddProtocol {
     NSArray *differences = [self differencesBetweenOldSource:@"@protocol A @end @protocol B @end @interface Base @end @interface Base (Test) @end"
                                                    newSource:@"@protocol A @end @protocol B @end @interface Base @end @interface Base (Test) <A> @end"];

--- a/OCDiffTests/OCDAPIComparatorTests.m
+++ b/OCDiffTests/OCDAPIComparatorTests.m
@@ -1189,7 +1189,7 @@ static NSString * const OCDTestPath = @"test.h";
     XCTAssertEqualObjects(differences, @[], @"Unchanged test failed for %@", name);
 
     // Unchanged, different line number
-    differences = [self differencesBetweenOldSource:addition newSource:[@"" stringByAppendingString:addition]];
+    differences = [self differencesBetweenOldSource:addition newSource:[@"\n" stringByAppendingString:addition]];
     XCTAssertEqualObjects(differences, @[], @"Move to different line number test failed for %@", name);
 }
 

--- a/OCDiffTests/OCDAPIComparatorTests.m
+++ b/OCDiffTests/OCDAPIComparatorTests.m
@@ -458,6 +458,24 @@ static NSString * const OCDTestPath = @"test.h";
                       addition:@"@interface Base @end @interface Base (Test) @property int testProperty; @end"];
 }
 
+- (void)testAnonymousCategory {
+    [self testAddRemoveForName:@"Base ()"
+                          base:@"@interface Base @end"
+                      addition:@"@interface Base @end @interface Base () @end"];
+}
+
+- (void)testAnonymousCategoryMethod {
+    [self testAddRemoveForName:@"-[Base testMethod]"
+                          base:@"@interface Base @end @interface Base () @end"
+                      addition:@"@interface Base @end @interface Base () -(void)testMethod; @end"];
+}
+
+- (void)testAnonymousCategoryProperty {
+    [self testAddRemoveForName:@"Base.testProperty"
+                          base:@"@interface Base @end @interface Base () @end"
+                      addition:@"@interface Base @end @interface Base () @property int testProperty; @end"];
+}
+
 - (void)testCategoryModificationAddProtocol {
     NSArray *differences = [self differencesBetweenOldSource:@"@protocol A @end @protocol B @end @interface Base @end @interface Base (Test) @end"
                                                    newSource:@"@protocol A @end @protocol B @end @interface Base @end @interface Base (Test) <A> @end"];
@@ -1171,7 +1189,7 @@ static NSString * const OCDTestPath = @"test.h";
     XCTAssertEqualObjects(differences, @[], @"Unchanged test failed for %@", name);
 
     // Unchanged, different line number
-    differences = [self differencesBetweenOldSource:addition newSource:[@"\n" stringByAppendingString:addition]];
+    differences = [self differencesBetweenOldSource:addition newSource:[@"" stringByAppendingString:addition]];
     XCTAssertEqualObjects(differences, @[], @"Move to different line number test failed for %@", name);
 }
 


### PR DESCRIPTION
This closes https://github.com/mattstevens/objc-diff/issues/8. I've verified that tests pass and that my local invocation generates the expected output now.
